### PR TITLE
Update test command in GitHub workflow to include JUnit XML output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Run tests
       run: |
         source .venv/bin/activate
-        pytest --cov=./ || exit_code=$?
+        pytest --cov --junitxml=junit.xml -o junit_family=legacy || exit_code=$?
         echo "exit_code=$exit_code" >> $GITHUB_ENV
 
     - name: Upload Coverage Report as Artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Run tests
       run: |
         source .venv/bin/activate
-        pytest --cov --junitxml=junit.xml -o junit_family=legacy --cov-report=html || exit_code=$?
+        pytest --cov --junitxml=junit.xml -o junit_family=legacy --cov-report=html --cov-report=xml || exit_code=$?
         echo "exit_code=$exit_code" >> $GITHUB_ENV
 
     - name: Upload Coverage Report as Artifact
@@ -53,6 +53,12 @@ jobs:
       with:
         name: code-coverage-report
         path: htmlcov/
+
+    - name: Upload results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Run tests
       run: |
         source .venv/bin/activate
-        pytest --cov --junitxml=junit.xml -o junit_family=legacy || exit_code=$?
+        pytest --cov --junitxml=junit.xml -o junit_family=legacy --cov-report=html || exit_code=$?
         echo "exit_code=$exit_code" >> $GITHUB_ENV
 
     - name: Upload Coverage Report as Artifact

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ pyrightconfig.json
 /token.pickle
 cache.db
 config.yaml
+junit.xml


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/test.yml` file to enhance the test reporting process by generating a JUnit XML report.

Enhancements to test reporting:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L48-R48): Modified the `pytest` command to include `--junitxml=junit.xml -o junit_family=legacy` options for generating a JUnit XML report.

---

Followed instructions here: https://docs.codecov.com/docs/test-analytics-beta

---

New output:

```
4s
Run codecov/test-results-action@v[1](https://github.com/GabLeRoux/time-sync-tools/actions/runs/11658656465/job/32458019884?pr=7#step:10:1)
==> linux OS detected
https://cli.codecov.io/latest/linux/codecov.SHA256SUM
gpg: directory '/home/runner/.gnupg' created
gpg: keybox '/home/runner/.gnupg/pubring.kbx' created
gpg: /home/runner/.gnupg/trustdb.gpg: trustdb created
gpg: key 806BB28AED779869: public key "Codecov Uploader (Codecov Uploader Verification Key) <security@codecov.io>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: Signature made Fri Oct 18 16:02:53 2024 UTC
gpg:                using RSA key 27034E7FDB850E0BBC2C62FF806BB28AED779869
gpg: Good signature from "Codecov Uploader (Codecov Uploader Verification Key) <security@codecov.io>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 2703 4E7F DB85 0E0B BC2C  62FF 806B B28A ED77 9869
==> Uploader SHASUM verified (452ad3c57dc4ff698e9ca36786a2d09be5db254c32c4a4fb6d08c18[14](https://github.com/GabLeRoux/time-sync-tools/actions/runs/11658656465/job/32458019884?pr=7#step:10:15)6e4d8c1  codecov)
==> Running version latest
==> Running version v0.8.0
==> Running command '/home/runner/work/_actions/codecov/test-results-action/v1/dist/codecov do-upload'
/home/runner/work/_actions/codecov/test-results-action/v1/dist/codecov do-upload -C 4c9d52c5f5c858e0b6d9096fa4a2e51e9546e566 --report-type test_results
info - 2024-11-04 05:35:05,5[19](https://github.com/GabLeRoux/time-sync-tools/actions/runs/11658656465/job/32458019884?pr=7#step:10:20) -- ci service found: github-actions
warning - [20](https://github.com/GabLeRoux/time-sync-tools/actions/runs/11658656465/job/32458019884?pr=7#step:10:21)24-11-04 05:35:05,527 -- No config file could be found. Ignoring config.
info - 2024-11-04 05:35:05,543 -- Found 1 test_results files to report
info - 2024-11-04 05:35:05,543 -- > /home/runner/work/time-sync-tools/time-sync-tools/junit.xml
info - 2024-11-04 05:35:06,037 -- Process Upload complete
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced testing process with the addition of JUnit XML report generation for better CI/CD integration. 
	- Maintained existing exit code handling to ensure workflow integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->